### PR TITLE
Removed obsolete center tag.

### DIFF
--- a/views/pages/login.ejs
+++ b/views/pages/login.ejs
@@ -1,25 +1,25 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <!-- Required meta tags -->
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
 
     <!-- Bootstrap CSS -->
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous" />
 
     <title>Welcome to Yet another todo app</title>
   </head>
   <body>
     <div class="container">
-    <center>
-    <h1>Notes app for Atlas Hackathon</h1>
-  <a class="hollow button primary" href="auth/google">
-    <img width="15px" style="margin-bottom:3px; margin-right:5px" alt="Google login" src="https://upload.wikimedia.org/wikipedia/commons/thumb/5/53/Google_%22G%22_Logo.svg/512px-Google_%22G%22_Logo.svg.png" />
-    Sign in with Google
-  </a>
-  </center>
-</div>
+      <div class="text-center">
+        <h1>Notes app for Atlas Hackathon</h1>
+        <a class="hollow button primary" href="auth/google">
+          <img width="15px" style="margin-bottom: 3px; margin-right: 5px" alt="Google login" src="https://upload.wikimedia.org/wikipedia/commons/thumb/5/53/Google_%22G%22_Logo.svg/512px-Google_%22G%22_Logo.svg.png" />
+          Sign in with Google
+        </a>
+      </div>
+    </div>
 
     <!-- Optional JavaScript -->
     <!-- jQuery first, then Popper.js, then Bootstrap JS -->


### PR DESCRIPTION
* Having a `<center>` tag is deprecated and will not work.
* Used the right bootstrap class `.text-center`.

For more info on `<center>` tag deprecation, please [see this](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/center):

![image](https://user-images.githubusercontent.com/1830380/193358504-d79fe461-7925-4a0e-9207-2bbee0fafcad.png)
